### PR TITLE
replace no longer supported node-spi with spi-device

### DIFF
--- a/examples/flash.js
+++ b/examples/flash.js
@@ -1,9 +1,9 @@
-var LPD8806 = require('LPD8806');
+var LPD8806 = require('../lib/LPD8806');
 
 // npm install async
 var async = require("async");
 
-var leds = new LPD8806(96, '/dev/spidev1.0');
+var leds = new LPD8806(96, 0, 0);
 
 // Flash ledstrip by manipulation of the color brightness
 function flash(r, g, b, speed){

--- a/examples/rainbow.js
+++ b/examples/rainbow.js
@@ -1,6 +1,6 @@
-var LPD8806 = require('LPD8806');
+var LPD8806 = require('../lib/LPD8806');
 var ledCount = 96;
-var leds = new LPD8806(ledCount, '/dev/spidev1.0');
+var leds = new LPD8806(ledCount, 0, 0);
 
 /** process.nextTick to avoid blocking it all the time */
 function rainbow(brightness){

--- a/lib/LPD8806.js
+++ b/lib/LPD8806.js
@@ -1,10 +1,12 @@
 /* MIT license */
 
-var SPI = require('spi'),
+var SPI = require('spi-device'),
     Color = require("color");
 
 var ledCount = 32,
-    device = '/dev/spidev0.0',
+    spiBus = 0,
+    spiDevice = 0,
+    spiMaxSpeed = 1000000,
     ChannelOrder = {
         "RGB" : [0,1,2], // Probably not used, here for clarity
         "GRB" : [1,0,2], // Strands from Adafruit and some others (default)
@@ -16,14 +18,13 @@ var ledCount = 32,
     gamma = new Buffer(256);
     
 
-var LPD8806 = function(leds, dev, options){
-    options = options || {};
+var LPD8806 = function(leds, bus, device, options){
+    options = options || {'maxSpeed' : spiMaxSpeed};
     ledCount = leds || ledCount;
-    device = dev || device;
+    spiBus = bus || spiBus;
+    spiDevice = device || spiDevice;
 
-    this.spi = new SPI.Spi(device, options, function(s){
-      s.open();
-    });
+    this.spi = SPI.openSync(spiBus, spiDevice, options);
 
     for(var i = 0; i < ledCount; i++){
         buffer[i] = new Buffer([0x80, 0x80, 0x80]);
@@ -75,7 +76,14 @@ LPD8806.prototype.update = function(){
     var _buffer = buffer.slice(0, buffer.length);
     _buffer.push(new Buffer([0x00, 0x00, 0x00]));
     _buffer.push(new Buffer([0x00]));
-    this.spi.write(Buffer.concat(_buffer));
+    var adjustedBuffer = Buffer.concat(_buffer);
+
+    let message = [{
+        sendBuffer: adjustedBuffer,
+        byteLength: adjustedBuffer.length,
+        speedHz: spiMaxSpeed
+    }];
+    this.spi.transferSync(message);
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "lpd8806-async",
+  "version": "0.2.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "spi-device": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/spi-device/-/spi-device-2.0.8.tgz",
+      "integrity": "sha512-VrIdxqUvlnFT+cGYF1ljVauEqyacB/m9uIN3PWRtw4ykfRtl4Ob+lJk0exxkuCWTlvg2SNZeVqHiuMiypfKfZg==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.2",
   "private": false,
   "dependencies": {
-    "spi": "*",
-    "color": "*"
+    "color": "*",
+    "spi-device": "^2.0.8"
   },
   "description": "Non-blocking LPD8806 NodeJS general library",
   "main": "./lib/LPD8806",


### PR DESCRIPTION
With the no longer supported node module 'node-spi' compilation was no longer successfull (russtheaerialist-retired-projects/node-spi#32).